### PR TITLE
Added .dockerignore file to exclude some folders and files that are not strictly required for launch the API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+env
+pip-log.txt
+pip-delete-this-directory.txt
+.tox
+# If coverage run -m pytest was runned
+.coverage       
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+# Excludes bank_api.log
+*.log           
+.git*
+.mypy_cache
+# If coverage run -m pytest was runned
+.pytest_cache   
+.hypothesis
+#
+# Added in last version
+#
+# For subdirectories
+*/__pycache__    
+# If some coverage html was runned
+/htmlcov   
+# Not required in prod img     
+/tests          
+# Excludes .dockerignore-dev and .dockerignore-prod
+.dockerignore*  
+# Excludes bank_102.db (if the api was runned)
+*.db          
+# Excludes bank_insomnia-v1.json  
+*.json      
+# Excludes building config    
+Dockerfile      
+# Excludes README.md
+*.md            


### PR DESCRIPTION
Hello team, I have used as base the file that Camilo shared yesterday. Some lines were added to clean up as much as possible the image.
I have tested after doing the build with the command

`docker run -it bank-api sh`

then `ls` and I get the bank_api folder and the requirements_api.txt file
Then I have run the command

`docker run -p 9000:9000 bank-api`

and the api behaves as expected.
Please take a look!

To remark:
At first, the idea was to create two .dockerignore files, one for production and other for dev, but since I have not found how to specify which one to use and the official documentation
[Docker Build Commandlines](https://docs.docker.com/engine/reference/commandline/build/#build-with--)
has not helped me, I have opted to upload only the production one.
