### PR TITLE
Add new job build-image to Build and Push to Dockerhub new image from main branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: kevingerardo23/bank-api:${{ vars.MAJOR }}.${{ vars.MINOR }}-${{ date +%s }}
+          tags: kevingerardo23/bank-api:${{ vars.MAJOR }}.${{ vars.MINOR }}-${{ github.run_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,4 @@ jobs:
           push: true
           tags: kevingerardo23/bank-api:${{ vars.MAJOR }}.${{ vars.MINOR }}
       - name: Update MINOR version variable
-        run: echo "::set-env name=MINOR::${${{ vars.MINOR}}+1}"
+        run: echo "::set-output name=MINOR::${${{ vars.MINOR }}+1}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,17 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-
       # To enable logout remove credentials
       - name: Login docker hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
           tags: kevingerardo23/bank-api:${{ vars.MAJOR }}.${{ vars.MINOR }}
+      - name: Update MINOR versionvariable
+        run: echo "::set-env name=MINOR::${{ vars.MINOR }}+1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
   build-image-and-push:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
       - name: Build Docker Image
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
+      # To enable logout remove credentials
       - name: Login docker hub
         uses: docker/login-action@v2
         with:
@@ -49,4 +50,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: kevingerardo23/bank-api:${{ secrets.MAJOR }}.${{ secrets.MINOR }}
+          tags: kevingerardo23/bank-api:${{ vars.MAJOR }}.${{ vars.MINOR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Login docker hub
-        uses: docker/login.action@v1
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,16 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Build Docker Image
-        uses: docker/build-push-action@v1
+
+      - name: Login docker hub
+        uses: docker/login.action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push Docker
+        uses: docker/build-push-action@v2
+        with:
           context: .
           push: true
           repository: kevingerardo23/bank-api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: kevingerardo23/bank-api:${{ vars.MAJOR }}.${{ vars.MINOR }}
-      - name: Update MINOR version variable
-        run: echo "::set-output name=MINOR::${${{ vars.MINOR }}+1}"
+          tags: kevingerardo23/bank-api:${{ vars.MAJOR }}.${{ vars.MINOR }}-$(date +%s)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: kevingerardo23/bank-api:${{ vars.MAJOR }}.${{ vars.MINOR }}-$(date +%s)
+          tags: kevingerardo23/bank-api:${{ vars.MAJOR }}.${{ vars.MINOR }}-${{ date +%s }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,11 @@ jobs:
       #- name: "Example show SonarQube Quality Gate Status value"
       #  run: echo "The Quality Gate status is ${{ steps.sonarqube-quality-gate-check.outputs.quality-gate-status }}"
   build-image-and-push:
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-      # To enable logout remove credentials
       - name: Login docker hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
       #- name: "Example show SonarQube Quality Gate Status value"
       #  run: echo "The Quality Gate status is ${{ steps.sonarqube-quality-gate-check.outputs.quality-gate-status }}"
-  build-image-and-push:
+  build-image:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,5 @@ jobs:
           context: .
           push: true
           tags: kevingerardo23/bank-api:${{ vars.MAJOR }}.${{ vars.MINOR }}
-      - name: Update MINOR versionvariable
-        run: echo "::set-env name=MINOR::${{ vars.MINOR }}+1"
+      - name: Update MINOR version variable
+        run: echo "::set-env name=MINOR::${${{ vars.MINOR}}+1}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Login docker hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name : Push to Dockerhub
-        run : docker push kevingerardo23/bank-api:${{ secrets.MAJOR }}.${{ secrets.MINOR }}
-      # - name: Build and Push Docker
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     context: .
-      #     push: true
-      #     repository: kevingerardo23/bank-api
-      #     tags: ${{ github.sha }}
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: kevingerardo23/bank-api:${{ secrets.MAJOR }}.${{ secrets.MINOR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
-name: Sonaar Scaner Analysis
+name: CI workflows
 on:
   push:
     branches:
       - main
-      - feature/quality-gate
+      - feature/build-image-ci-workflow
 jobs:
-  build-and-push:
+  sonnar-scanner-analysis:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -32,3 +32,15 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
       #- name: "Example show SonarQube Quality Gate Status value"
       #  run: echo "The Quality Gate status is ${{ steps.sonarqube-quality-gate-check.outputs.quality-gate-status }}"
+  build-image-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Docker Image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          context: .
+          push: true
+          repository: kevingerardo23/bank-api
+          tags: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and Push Docker
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          repository: kevingerardo23/bank-api
-          tags: ${{ github.sha }}
+      - name : Push to Dockerhub
+        run : docker push kevingerardo23/bank-api:${{ secrets.MAJOR }}.${{ secrets.MINOR }}
+      # - name: Build and Push Docker
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     context: .
+      #     push: true
+      #     repository: kevingerardo23/bank-api
+      #     tags: ${{ github.sha }}


### PR DESCRIPTION
- This pull request adds a new job to our CI pipeline called "build-image" that automates the process of building and pushing a Docker image from the main branch to Dockerhub.

- We implemented 2 Github action variables:
  - vars.MAJOR: Marks mayor release number
  - vars.MINOR: Marks minor release number

- We also used the GitHub action env variable:
  - github.run_number: retrieve the number of the action run.

- The job uses the Dockerfile in the root of the repository and builds the image with the latest changes from the main branch. Once the build is complete, the job pushes the image to our Dockerhub repository.

- This new job will help us streamline our deployment process and ensure that our Docker images are always up-to-date with the latest changes in the main branch and tag appropriately.

Please review the changes and let me know if there are any concerns or suggestions for improvement.