### PR TITLE
PRE-DEMO: Fixed bug on transaction when amount is bigger than origin balance

### DIFF
--- a/bank_api/resources/transaction_resource.py
+++ b/bank_api/resources/transaction_resource.py
@@ -56,7 +56,7 @@ def withdraw(transaction):
     origin_account = get_account(cbu_origin)
     origin_balance = origin_account['balance']
     if origin_balance < transaction['amount']:
-        raise Exception("The amount to withdraw is bigger than current balance")
+        return make_response(jsonify(msg=f"The amount to withdraw is bigger than current balance"),404)
     new_balance = origin_balance - transaction['amount']
     account = update_balance(cbu_origin, new_balance)
     transaction = save_transaction_to_db(transaction)
@@ -75,18 +75,19 @@ def transaction(transaction):
     cbu_origin = transaction['origin_account']
     origin_account = get_account(cbu_origin)
     origin_balance = origin_account['balance']
-    if origin_balance >= transaction['amount']:
-        new_origin_balance = origin_balance - transaction['amount']
-        account_origin = update_balance(cbu_origin, new_origin_balance)
-        new_destiny_balance = destiny_balance + transaction['amount']
-        account_final = update_balance(cbu_destiny, new_destiny_balance)
-        transaction = save_transaction_to_db(transaction)
-        return jsonify(
-            origin_account=transaction.origin_account,
-            final_account=transaction.final_account,
-            description=transaction.description,
-            amount=transaction.amount,
-            balance=account_origin.balance)
+    if origin_balance < transaction['amount']:
+        return make_response(jsonify(msg=f"The amount to withdraw is bigger than current balance"),404)
+    new_origin_balance = origin_balance - transaction['amount']
+    account_origin = update_balance(cbu_origin, new_origin_balance)
+    new_destiny_balance = destiny_balance + transaction['amount']
+    account_final = update_balance(cbu_destiny, new_destiny_balance)
+    transaction = save_transaction_to_db(transaction)
+    return jsonify(
+        origin_account=transaction.origin_account,
+        final_account=transaction.final_account,
+        description=transaction.description,
+        amount=transaction.amount,
+        balance=account_origin.balance)
 
 
 class TransactionResource(Resource):


### PR DESCRIPTION
This RP fixed a bug on endpoint /transactions , when the **amount** to withdraw is bigger than the origin account **balance** it raised an ERROR 500, with the fix now raises an ERROR 400 with a message "The amount to withdraw is bigger than current balance"